### PR TITLE
BG95 support, UDP receive for nRF91 and BG95

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ all:
 	@cd examples/imei-imsi-ccid && go build -o ../../bin/imei-imsi-ccid
 	@cd examples/simple && go build -o ../../bin/simple
 	@cd examples/send && go build -o ../../bin/send
-
+	@cd examples/receive && go build -o ../../bin/receive

--- a/at.go
+++ b/at.go
@@ -61,12 +61,6 @@ type Device interface {
 
 	AT() error
 
-	// Reboot device
-	Reboot() error
-
-	//	// SendCRLF sends a string to the device adding CRLF to the end of the line
-	//	SendCRLF(s string)
-
 	// GetIMSI reads the IMSI from the device
 	GetIMSI() (string, error)
 
@@ -75,10 +69,6 @@ type Device interface {
 
 	// GetCCID returns the CCID of the SIM
 	GetCCID() (string, error)
-
-	// SetAutoconnect turns on autoconnect if the autoconnect
-	// parameter is true and off if it is false
-	SetAutoconnect(autoconnect bool) error
 
 	// SetAPN sets the APN.  Be aware that this operation performs
 	// multiple transactions and reboots the device.
@@ -94,11 +84,6 @@ type Device interface {
 	// SetRadio turns the radio on if on is true and off is on is false. This (usually) invokes the AT+CFUN
 	// command
 	SetRadio(bool) error
-
-	// GetStats returns the most recent operational statistics.  Note that
-	// this translates to the AT+NUESTATS command and doesn't specify any
-	// parameters.
-	GetStats() (*Stats, error)
 
 	// CreateUDPSocket creates an UDP socket. If the port is non-zero,
 	// receiving is enabled and +NSONMI URCs will appear for any

--- a/bg95/bg96.go
+++ b/bg95/bg96.go
@@ -13,8 +13,21 @@ type bg95 struct {
 
 func New(serialDevice string, baudRate int) at.Device {
 	cmdIF := at.NewCommandInterface(serialDevice, baudRate)
+	cmdIF.AddErrorOutput("SEND FAIL")
+	cmdIF.AddSplitChars(">")
+	cmdIF.AddSuccessOutput("SEND OK")
 	return &bg95{
 		DefaultImplementation: at.DefaultImplementation{Cmd: cmdIF},
 		cmd:                   cmdIF,
 	}
+}
+
+func (d *bg95) Start() error {
+	if err := d.Cmd.Start(); err != nil {
+		return err
+	}
+	// BG95 has echo turned on by default. Turn off
+	return d.Cmd.Transact("ATE0", func(s string) error {
+		return nil
+	})
 }

--- a/bg95/bg96.go
+++ b/bg95/bg96.go
@@ -1,1 +1,20 @@
 package bg95
+
+import "github.com/lab5e/at"
+
+// DefaultBaudRate is the default baud rate for the BG95 UART
+const DefaultBaudRate = 115200
+
+type bg95 struct {
+	at.DefaultImplementation
+
+	cmd *at.CommandInterface
+}
+
+func New(serialDevice string, baudRate int) at.Device {
+	cmdIF := at.NewCommandInterface(serialDevice, baudRate)
+	return &bg95{
+		DefaultImplementation: at.DefaultImplementation{Cmd: cmdIF},
+		cmd:                   cmdIF,
+	}
+}

--- a/bg95/commands.go
+++ b/bg95/commands.go
@@ -1,4 +1,4 @@
-package nrf91
+package bg95
 
 import (
 	"errors"
@@ -6,12 +6,12 @@ import (
 	"strings"
 )
 
-func (d *nrf91) GetCCID() (string, error) {
+func (d *bg95) GetCCID() (string, error) {
 	iccid := ""
-	err := d.cmd.Transact("AT%XICCID", func(s string) error {
+	err := d.cmd.Transact("AT+CCID", func(s string) error {
 		parts := strings.Split(s, ":")
 		if len(parts) != 2 {
-			log.Printf("Unable to parse response AT%%XICCID: %s", s)
+			log.Printf("Unable to parse response AT+ICCID: %s", s)
 			return errors.New("unable to parse response")
 		}
 		iccid = strings.TrimSpace(parts[1])

--- a/bg95/socket.go
+++ b/bg95/socket.go
@@ -1,0 +1,99 @@
+package bg95
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/lab5e/at"
+)
+
+/*OK
+[14:00:37][AT] Context activated OK
+[14:00:37][AT] AT+QIOPEN=1,1,"UDP","172.16.15.14", 1234, 3030,0
+OK
+
++QIOPEN: 1,0
+[14:00:37][AT] Socket opened OK
+[14:00:37][AT] Sending UDP message...
+[14:00:37][AT] AT+QISEND=1,22
+>
+[14:00:37][INFO] Sending 22 bytes to 172.16.15.14 on port 1234
+[14:00:37][AT] UDP message sent ok
+[14:00:38][AT] AT+QICLOSE=1
+OK
+*/
+
+var socketno = 0
+
+// Note: There is only a single socket in the LTE modem. The port parameter may be 0, then the
+// socket won't be bound to a port.
+func (d *bg95) CreateUDPSocket(port int) (int, error) {
+	socketno++
+	if socketno > 11 {
+		return 0, errors.New("sockets exhausted")
+	}
+	err := d.cmd.Transact(fmt.Sprintf(`AT+QIOPEN=1,%d,"UDP SERVICE","0.0.0.0",%d,1`, socketno, port), func(s string) error {
+		// The module will return <connection id>,<error> and <error> should - obviously be 0
+		if strings.HasPrefix(s, "+QIOPEN") {
+			elems := strings.Split(s, ":")
+			if len(elems) != 2 {
+				log.Printf("Error parsing result from AT+QIOPEN: %s", s)
+				return errors.New("could not parse return value from AT+QIOPEN command")
+			}
+			fields := strings.Split(elems[1], ",")
+			if len(fields) != 2 {
+				log.Printf("Expected 2 fields returned but got %d: %s", len(fields), s)
+				return errors.New("could not parse response fields from AT+QIOPEN")
+			}
+			connID, err := strconv.Atoi(strings.TrimSpace(fields[0]))
+			if err != nil {
+				log.Printf("Invalid connection ID (field #1) from module: %s", s)
+				return errors.New("could not parse connection ID")
+			}
+			if strings.TrimSpace(fields[1]) != "0" {
+				log.Printf("Got error response from AT+QIOPEN: %s", s)
+				return errors.New("error code returned from module")
+			}
+			socketno = connID
+			return nil
+		}
+		return nil
+	})
+	return socketno, err
+}
+
+var errDummy = errors.New("not an error")
+
+// This might not work with arbitrary binary data since the data is sent as a string
+func (d *bg95) SendUDP(socket int, address net.IP, remotePort int, data []byte) (int, error) {
+	// Start by sending AT+SEND and when we receive the '>' character send the payload. We should get a "SEND OK" or "SEND ERROR" back
+	err := d.cmd.Transact(fmt.Sprintf(`AT+QISEND=%d,%d,"%s",%d\r\n%s`,
+		socket, len(data), address.String(), remotePort, string(data)), func(s string) error {
+		if s == "SEND ERROR" {
+			return errors.New("send error")
+		}
+		if s == "SEND OK" {
+			return errDummy
+		}
+		return nil
+	})
+	if err == errDummy {
+		return len(data), nil
+	}
+	return 0, err
+}
+
+// Note: Receive has a 10 second timeout
+func (d *bg95) ReceiveUDP(socket int, length int) (*at.ReceivedData, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (d *bg95) CloseUDPSocket(socket int) error {
+	return d.cmd.Transact(fmt.Sprintf("AT+QICLOSE=%d", socket), func(s string) error {
+		return nil
+	})
+}

--- a/default_cmd.go
+++ b/default_cmd.go
@@ -1,0 +1,132 @@
+package at
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// DefeaultImplementation is a default implementation
+type DefaultImplementation struct {
+	Cmd *CommandInterface
+}
+
+func (d *DefaultImplementation) Start() error {
+	return d.Cmd.Start()
+}
+
+func (d *DefaultImplementation) Close() {
+	d.Cmd.Close()
+}
+
+func (d *DefaultImplementation) AT() error {
+	return d.Cmd.Transact("AT", func(s string) error {
+		return nil
+	})
+}
+
+func (d *DefaultImplementation) SetDebug(debug bool) {
+	d.Cmd.SetDebug(debug)
+}
+
+func (d *DefaultImplementation) GetIMSI() (string, error) {
+	var imsi string
+
+	err := d.Cmd.Transact("AT+CIMI", func(s string) error {
+		sub := IMSIRegex.FindStringSubmatch(s)
+		if len(sub) > 0 {
+			imsi = sub[1]
+		}
+		return nil
+	})
+
+	return imsi, err
+}
+
+func (d *DefaultImplementation) GetIMEI() (string, error) {
+	var imei string
+
+	err := d.Cmd.Transact("AT+CGSN", func(s string) error {
+		if strings.TrimSpace(s) == "" {
+			return nil
+		}
+		imei = s
+		return nil
+	})
+
+	return imei, err
+}
+
+func (d *DefaultImplementation) SetRadio(on bool) error {
+	ind := 0
+	if on {
+		ind = 1
+	}
+	return d.Cmd.Transact(fmt.Sprintf("AT+CFUN=%d", ind), nil)
+}
+
+func (d *DefaultImplementation) GetAddr() (int, string, error) {
+	var cid int
+	var addr string
+
+	err := d.Cmd.Transact("AT+CGPADDR", func(s string) error {
+		var err error
+		if st := strings.TrimPrefix(s, "+CGPADDR: "); st != s {
+			parts := strings.Split(st, ",")
+			if len(parts) < 2 {
+				return errors.New("missing field in response")
+			}
+
+			cid, err = strconv.Atoi(parts[0])
+			if err != nil {
+				return errors.New("invalid CID")
+			}
+
+			addr = TrimQuotes(parts[1])
+		}
+		return nil
+	})
+
+	return cid, addr, err
+}
+
+func (d *DefaultImplementation) SetAPN(apn string) error {
+
+	err := d.Cmd.Transact(fmt.Sprintf("AT+CGDCONT=1,\"IP\",\"%s\"", apn), nil)
+	if err != nil {
+		return err
+	}
+
+	err = d.Cmd.Transact("AT+CGACT=1,1", func(s string) error {
+		return nil
+	})
+	return err
+}
+
+func (d *DefaultImplementation) GetAPN() (*APN, error) {
+	var apn = &APN{}
+
+	err := d.Cmd.Transact("AT+CGDCONT?", func(s string) error {
+		var err error
+		if st := strings.TrimPrefix(s, "+CGDCONT: "); st != s {
+			parts := strings.Split(st, ",")
+			if len(parts) < 4 {
+				return errors.New("missing some fields in response")
+			}
+
+			apn.ContextIdentifier, err = strconv.Atoi(parts[0])
+			if err != nil {
+				return errors.New("invalid CID")
+			}
+			apn.PDPType = TrimQuotes(parts[1])
+			apn.Name = TrimQuotes(parts[2])
+			apn.Address = TrimQuotes(parts[3])
+			return nil
+		}
+
+		return nil
+	})
+
+	return apn, err
+}

--- a/examples/imei-imsi-ccid/main.go
+++ b/examples/imei-imsi-ccid/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/lab5e/at"
+	"github.com/lab5e/at/bg95"
 	"github.com/lab5e/at/n211"
 	"github.com/lab5e/at/nrf91"
 )
@@ -19,6 +20,8 @@ func main() {
 	switch strings.ToLower(os.Args[1]) {
 	case "nrf91":
 		device = nrf91.New(os.Args[2], nrf91.DefaultBaudRate)
+	case "bg95":
+		device = bg95.New(os.Args[2], bg95.DefaultBaudRate)
 	case "n211":
 		device = n211.New(os.Args[2], n211.DefaultBaudRate)
 	default:

--- a/examples/send/main.go
+++ b/examples/send/main.go
@@ -8,6 +8,7 @@ import (
 	"net"
 
 	"github.com/lab5e/at"
+	"github.com/lab5e/at/bg95"
 	"github.com/lab5e/at/n211"
 	"github.com/lab5e/at/nrf91"
 )
@@ -31,6 +32,8 @@ func main() {
 	switch strings.ToLower(deviceType) {
 	case "n211":
 		device = n211.New(serialDevice, n211.DefaultBaudRate)
+	case "bg95":
+		device = bg95.New(serialDevice, bg95.DefaultBaudRate)
 	case "nrf91":
 		device = nrf91.New(serialDevice, nrf91.DefaultBaudRate)
 	default:

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -6,11 +6,10 @@ import (
 	"strings"
 
 	"github.com/lab5e/at"
+	"github.com/lab5e/at/bg95"
 	"github.com/lab5e/at/n211"
 	"github.com/lab5e/at/nrf91"
 )
-
-const baudRate = 9600
 
 func main() {
 	if len(os.Args) < 3 {
@@ -24,6 +23,8 @@ func main() {
 	switch strings.ToLower(deviceType) {
 	case "n211":
 		device = n211.New(serialDevice, n211.DefaultBaudRate)
+	case "bg95":
+		device = bg95.New(serialDevice, bg95.DefaultBaudRate)
 	case "nrf91":
 		device = nrf91.New(serialDevice, nrf91.DefaultBaudRate)
 	default:

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/lab5e/at
 
 go 1.15
 
-require github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07
+require (
+	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07
+	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07 h1:UyzmZLoiDWMRywV4DUYb9Fbt8uiOSooupjTq10vpvnU=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf h1:2ucpDCmfkl8Bd/FsLtiD653Wf96cW37s+iGx93zsu4k=
+golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/nrf91/nrf91.go
+++ b/nrf91/nrf91.go
@@ -5,19 +5,15 @@ import "github.com/lab5e/at"
 const DefaultBaudRate = 115200
 
 type nrf91 struct {
+	at.DefaultImplementation
+
 	cmd *at.CommandInterface
 }
 
 func New(serialDevice string, baudRate int) at.Device {
+	cmdIF := at.NewCommandInterface(serialDevice, baudRate)
 	return &nrf91{
-		cmd: at.NewCommandInterface(serialDevice, baudRate),
+		DefaultImplementation: at.DefaultImplementation{Cmd: cmdIF},
+		cmd:                   cmdIF,
 	}
-}
-
-func (d *nrf91) Start() error {
-	return d.cmd.Start()
-}
-
-func (d *nrf91) Close() {
-	d.cmd.Close()
 }


### PR DESCRIPTION
Implement BG95 support and UDP receive for BG95 and nRF91

* Rewrite generic library to handle BG95 quirks 
* Receive example. Quite crude but works 
* Remove Reboot(), SetAutoconnect() and GetStats() from the Device interface since only N211 supports this.
* Move generic commands into a common type that the devices extend
* 